### PR TITLE
Move config into package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-SOURCE_PATH = src/slides.md
-OUTPUT_HTML_PATH = dist/slides.html
-OUTPUT_PDF_PATH = dist/slides.pdf
-OUTPUT_PP_PATH = dist/slides.pptx
-
 usage :
 	@grep '^[^#[:space:]].*:' Makefile
 
@@ -10,19 +5,19 @@ install :
 	npm install
 
 watch_html :
-	npx @marp-team/marp-cli -w ${SOURCE_PATH} -o ${OUTPUT_HTML_PATH}
+	npx @marp-team/marp-cli -w
 
 build_html :
-	npx @marp-team/marp-cli ${SOURCE_PATH} -o ${OUTPUT_HTML_PATH}
+	npx @marp-team/marp-cli
 
 build_pdf :
-	npx @marp-team/marp-cli ${SOURCE_PATH} --pdf --allow-local-files -o ${OUTPUT_PDF_PATH}
+	npx @marp-team/marp-cli --pdf
 
 build_pp :
-	npx @marp-team/marp-cli ${SOURCE_PATH} --pptx --allow-local-files -o ${OUTPUT_PP_PATH}
+	npx @marp-team/marp-cli --pptx
 
 build_all :
 	make build_html && make build_pdf && make build_pp
 
 clean :
-	rm ${OUTPUT_HTML_PATH} ${OUTPUT_PDF_PATH} ${OUTPUT_PP_PATH}
+	rm dist/*.{html,pdf,pptx}

--- a/package.json
+++ b/package.json
@@ -10,5 +10,10 @@
   "license": "Apache2",
   "devDependencies": {
     "@marp-team/marp-cli": "^0.16.1"
+  },
+  "marp": {
+    "allowLocalFiles": true,
+    "inputDir": "src",
+    "output": "dist"
   }
 }


### PR DESCRIPTION
Move the configuration options for the input and output directories as well as whether to allow local files into the `marp` section of `package.json`.

This also means that the Makefile can be simplified as those options no longer need to be passed as arguments to the CLI commands.